### PR TITLE
Fix "NULL pointer to instance" error

### DIFF
--- a/BuildingFortifications/scripts/4_World/BuildingFortifications/ItemBase/CombinationLock.c
+++ b/BuildingFortifications/scripts/4_World/BuildingFortifications/ItemBase/CombinationLock.c
@@ -12,8 +12,7 @@ modded class CombinationLock
 			{				
 				InventoryLocation inventory_location = new InventoryLocation;
 				GetInventory().GetCurrentInventoryLocation( inventory_location );			
-				BF_DB.GetInventory().SetSlotLock( inventory_location.GetSlot(), false );
-				BF_DDB.GetInventory().SetSlotLock( inventory_location.GetSlot(), false );
+				parent.GetInventory().SetSlotLock( inventory_location.GetSlot(), false );
 		
 				if (player)
 					player.ServerDropEntity( this );


### PR DESCRIPTION
@Dumpgrah For your consideration, this PR fixes a "NULL pointer to instance" error when unlocking a combination lock that is attached to a Building Fortifications door.